### PR TITLE
Use an LRU in AutoRefreshCache

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -163,6 +163,17 @@
   revision = "77c84b1dd69c41b74fe0a94ca8ee257d85947327"
 
 [[projects]]
+  digest = "1:d15ee511aa0f56baacc1eb4c6b922fa1c03b38413b6be18166b996d82a0156ea"
+  name = "github.com/hashicorp/golang-lru"
+  packages = [
+    ".",
+    "simplelru",
+  ]
+  pruneopts = "UT"
+  revision = "7087cb70de9f7a8bc0a10c375cb0d2280a8edf9c"
+  version = "v0.5.1"
+
+[[projects]]
   digest = "1:c0d19ab64b32ce9fe5cf4ddceba78d5bc9807f0016db6b1183599da3dcc24d10"
   name = "github.com/hashicorp/hcl"
   packages = [
@@ -492,10 +503,12 @@
     "github.com/golang/protobuf/proto",
     "github.com/golang/protobuf/ptypes",
     "github.com/golang/protobuf/ptypes/duration",
+    "github.com/golang/protobuf/ptypes/struct",
     "github.com/golang/protobuf/ptypes/timestamp",
     "github.com/graymeta/stow",
     "github.com/graymeta/stow/local",
     "github.com/graymeta/stow/s3",
+    "github.com/hashicorp/golang-lru",
     "github.com/magiconair/properties/assert",
     "github.com/mitchellh/mapstructure",
     "github.com/pkg/errors",

--- a/utils/auto_refresh_cache.go
+++ b/utils/auto_refresh_cache.go
@@ -113,7 +113,6 @@ func (w *autoRefreshCache) GetOrCreate(item CacheItem) (CacheItem, error) {
 		return val.(CacheItem), nil
 	}
 
-	//fmt.Println("adding")
 	w.lruMap.Add(item.ID(), item)
 	return item, nil
 }

--- a/utils/auto_refresh_cache.go
+++ b/utils/auto_refresh_cache.go
@@ -71,7 +71,7 @@ func NewAutoRefreshCache(syncCb CacheSyncItem, syncRateLimiter RateLimiter, resy
 
 	cache := &autoRefreshCache{
 		syncCb:          syncCb,
-		lruMap:          *lruCache,
+		lruMap:          lruCache,
 		syncRateLimiter: syncRateLimiter,
 		resyncPeriod:    resyncPeriod,
 		scope:           scope,
@@ -88,7 +88,7 @@ func NewAutoRefreshCache(syncCb CacheSyncItem, syncRateLimiter RateLimiter, resy
 // Sync is run as a fixed-interval-scheduled-task, and is skipped if sync from previous cycle is still running.
 type autoRefreshCache struct {
 	syncCb          CacheSyncItem
-	lruMap          lru.Cache
+	lruMap          *lru.Cache
 	syncRateLimiter RateLimiter
 	resyncPeriod    time.Duration
 	scope           promutils.Scope

--- a/utils/auto_refresh_cache.go
+++ b/utils/auto_refresh_cache.go
@@ -2,11 +2,13 @@ package utils
 
 import (
 	"context"
+	"github.com/hashicorp/golang-lru"
+	"github.com/lyft/flytestdlib/logger"
+	"github.com/lyft/flytestdlib/promutils"
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"sync"
 	"time"
-
-	"github.com/lyft/flytestdlib/logger"
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 // AutoRefreshCache with regular GetOrCreate and Delete along with background asynchronous refresh. Caller provides
@@ -27,16 +29,50 @@ type CacheItem interface {
 	ID() string
 }
 
-type CacheSyncItem func(ctx context.Context, obj CacheItem) (CacheItem, error)
+// Possible actions for the cache to take as a result of running the sync function on any given cache item
+type CacheSyncAction int
 
-func NewAutoRefreshCache(syncCb CacheSyncItem, syncRateLimiter RateLimiter, resyncPeriod time.Duration) AutoRefreshCache {
-	cache := &autoRefreshCache{
-		syncCb:          syncCb,
-		syncRateLimiter: syncRateLimiter,
-		resyncPeriod:    resyncPeriod,
+const (
+	// The item returned has been updated and should be updated in the cache
+	Update CacheSyncAction = iota
+
+	// The item should be removed from the cache
+	Delete
+)
+
+type CacheSyncItem func(ctx context.Context, obj CacheItem) (
+	newItem CacheItem, result CacheSyncAction, err error)
+
+func getEvictionFunction(counter prometheus.Counter) func(key interface{}, value interface{}) {
+	return func(_ interface{}, _ interface{}) {
+		counter.Inc()
+	}
+}
+
+func NewAutoRefreshCache(syncCb CacheSyncItem, syncRateLimiter RateLimiter, resyncPeriod time.Duration,
+	size int, scope promutils.Scope) (AutoRefreshCache, error) {
+
+	var evictionFunction func(key interface{}, value interface{})
+
+	// If a scope is specified, we'll add a function to log a metric when evicting
+	if scope != nil {
+		counter := scope.MustNewCounter("lru_evictions", "Counter for evictions from LRU")
+		evictionFunction = getEvictionFunction(counter)
+	}
+	lruCache, err := lru.NewWithEvict(size, evictionFunction)
+	if err != nil {
+		return nil, err
 	}
 
-	return cache
+	cache := &autoRefreshCache{
+		syncCb:          syncCb,
+		lruMap:          *lruCache,
+		syncRateLimiter: syncRateLimiter,
+		resyncPeriod:    resyncPeriod,
+		scope:           scope,
+	}
+
+	return cache, nil
 }
 
 // Thread-safe general purpose auto-refresh cache that watches for updates asynchronously for the keys after they are added to
@@ -48,8 +84,10 @@ func NewAutoRefreshCache(syncCb CacheSyncItem, syncRateLimiter RateLimiter, resy
 type autoRefreshCache struct {
 	syncCb          CacheSyncItem
 	syncMap         sync.Map
+	lruMap          lru.Cache
 	syncRateLimiter RateLimiter
 	resyncPeriod    time.Duration
+	scope           promutils.Scope
 }
 
 func (w *autoRefreshCache) Start(ctx context.Context) {
@@ -57,7 +95,7 @@ func (w *autoRefreshCache) Start(ctx context.Context) {
 }
 
 func (w *autoRefreshCache) Get(id string) CacheItem {
-	if val, ok := w.syncMap.Load(id); ok {
+	if val, ok := w.lruMap.Get(id); ok {
 		return val.(CacheItem)
 	}
 	return nil
@@ -66,34 +104,42 @@ func (w *autoRefreshCache) Get(id string) CacheItem {
 // Return the item if exists else create it.
 // Create should be invoked only once. recreating the object is not supported.
 func (w *autoRefreshCache) GetOrCreate(item CacheItem) (CacheItem, error) {
-	if val, ok := w.syncMap.Load(item.ID()); ok {
+	if val, ok := w.lruMap.Get(item.ID()); ok {
 		return val.(CacheItem), nil
 	}
 
-	w.syncMap.Store(item.ID(), item)
+	w.lruMap.Add(item.ID(), item)
 	return item, nil
 }
 
+// This function is called internally by its own timer. Roughly, it will,
+//  - List keys
+//  - For each of the keys, call syncCb, which tells us if the item has been updated
+//    - If it has, then do a remove followed by an add.  We can get away with this because it is guaranteed that
+//      this loop will run to completion before the next one begins.
+//
+// What happens when the number of things that a user is trying to keep track of exceeds the size
+// of the cache?  Trivial case where the cache is size 1 and we're trying to keep track of two things.
+//  * Plugin asks for update on item 1 - cache evicts item 2, stores 1 and returns it unchanged
+//  * Plugin asks for update on item 2 - cache evicts item 1, stores 2 and returns it unchanged
+//  * Sync loop updates item 2, repeat
 func (w *autoRefreshCache) sync(ctx context.Context) {
-	w.syncMap.Range(func(key, value interface{}) bool {
-		if w.syncRateLimiter != nil {
-			err := w.syncRateLimiter.Wait(ctx)
+	keys := w.lruMap.Keys()
+	for _, k := range keys {
+		// If not ok, it means evicted between the item was evicted between calling the keys and the iteration loop
+		if value, ok := w.lruMap.Peek(k); ok {
+			newItem, result, err := w.syncCb(ctx, value.(CacheItem))
 			if err != nil {
-				logger.Warnf(ctx, "unexpected failure in rate-limiter wait %v", key)
-				return true
+				logger.Error(ctx, "failed to get latest copy of the item %v", key)
+			}
+
+			if result == Update {
+				w.lruMap.Remove(k)
+				w.lruMap.Add(k, newItem)
+
+			} else if result == Delete {
+				w.lruMap.Remove(k)
 			}
 		}
-		item, err := w.syncCb(ctx, value.(CacheItem))
-		if err != nil {
-			logger.Error(ctx, "failed to get latest copy of the item %v", key)
-		}
-
-		if item == nil {
-			w.syncMap.Delete(key)
-		} else {
-			w.syncMap.Store(key, item)
-		}
-
-		return true
-	})
+	}
 }

--- a/utils/auto_refresh_cache.go
+++ b/utils/auto_refresh_cache.go
@@ -2,13 +2,13 @@ package utils
 
 import (
 	"context"
-	"github.com/hashicorp/golang-lru"
+	"time"
+
+	lru "github.com/hashicorp/golang-lru"
 	"github.com/lyft/flytestdlib/logger"
 	"github.com/lyft/flytestdlib/promutils"
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"sync"
-	"time"
 )
 
 // AutoRefreshCache with regular GetOrCreate and Delete along with background asynchronous refresh. Caller provides
@@ -88,7 +88,6 @@ func NewAutoRefreshCache(syncCb CacheSyncItem, syncRateLimiter RateLimiter, resy
 // Sync is run as a fixed-interval-scheduled-task, and is skipped if sync from previous cycle is still running.
 type autoRefreshCache struct {
 	syncCb          CacheSyncItem
-	syncMap         sync.Map
 	lruMap          lru.Cache
 	syncRateLimiter RateLimiter
 	resyncPeriod    time.Duration

--- a/utils/auto_refresh_cache.go
+++ b/utils/auto_refresh_cache.go
@@ -139,7 +139,6 @@ func (w *autoRefreshCache) sync(ctx context.Context) {
 			}
 
 			if result == Update {
-				w.lruMap.Remove(k)
 				w.lruMap.Add(k, newItem)
 			} else if result == Delete {
 				w.lruMap.Remove(k)

--- a/utils/auto_refresh_cache.go
+++ b/utils/auto_refresh_cache.go
@@ -109,7 +109,6 @@ func (w *autoRefreshCache) Get(id string) CacheItem {
 // Create should be invoked only once. recreating the object is not supported.
 func (w *autoRefreshCache) GetOrCreate(item CacheItem) (CacheItem, error) {
 	if val, ok := w.lruMap.Get(item.ID()); ok {
-		//fmt.Println("existing")
 		return val.(CacheItem), nil
 	}
 

--- a/utils/auto_refresh_cache_test.go
+++ b/utils/auto_refresh_cache_test.go
@@ -2,120 +2,93 @@ package utils
 
 import (
 	"context"
+	"fmt"
+	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
-
-	atomic2 "sync/atomic"
-
-	"github.com/lyft/flytestdlib/atomic"
-	"github.com/stretchr/testify/assert"
 )
 
-type testCacheItem struct {
-	val          int
-	deleted      atomic.Bool
-	resyncPeriod time.Duration
-	synced       atomic.Int32
+const fakeCacheItemValueLimit = 10
+
+type fakeCacheItem struct {
+	id  string
+	val int
 }
 
-func (m *testCacheItem) ID() string {
-	return "id"
+func (f fakeCacheItem) ID() string {
+	return f.id
 }
 
-func (m *testCacheItem) moveNext() {
-	// change value and spare enough time for cache to process the change.
-	m.val++
-	time.Sleep(m.resyncPeriod * 5)
-}
-
-func (m *testCacheItem) syncItem(ctx context.Context, obj CacheItem) (CacheItem, error) {
-	defer func() { m.synced.Inc() }()
-
-	if m.deleted.Load() {
-		return nil, nil
+func syncFakeItem(_ context.Context, obj CacheItem) (CacheItem, CacheSyncAction, error) {
+	item := obj.(fakeCacheItem)
+	if item.val == fakeCacheItemValueLimit {
+		// After the item has gone through ten update cycles, leave it unchanged
+		return obj, Unchanged, nil
 	}
 
-	return m, nil
+	return fakeCacheItem{id: item.ID(), val: item.val + 1}, Update, nil
 }
 
-type testAutoIncrementItem struct {
-	val int32
+func syncFakeItemLagged(ctx context.Context, obj CacheItem) (CacheItem, CacheSyncAction, error) {
+	time.Sleep(100 * time.Millisecond)
+	return syncFakeItem(ctx, obj)
 }
 
-func (a *testAutoIncrementItem) ID() string {
-	return "autoincrement"
+func syncFakeItemAlwaysDelete(_ context.Context, obj CacheItem) (CacheItem, CacheSyncAction, error) {
+	return obj, Delete, nil
 }
 
-func (a *testAutoIncrementItem) syncItem(ctx context.Context, obj CacheItem) (CacheItem, error) {
-	atomic2.AddInt32(&a.val, 1)
-	return a, nil
-}
-
-func TestCache(t *testing.T) {
+func TestCacheTwo(t *testing.T) {
 	testResyncPeriod := time.Millisecond
 	rateLimiter := NewRateLimiter("mockLimiter", 100, 1)
 
-	item := &testCacheItem{
-		val:          0,
-		resyncPeriod: testResyncPeriod,
-		deleted:      atomic.NewBool(false),
-		synced:       atomic.NewInt32(0)}
-	cache := NewAutoRefreshCache(item.syncItem, rateLimiter, testResyncPeriod)
+	t.Run("normal operation", func(t *testing.T) {
+		// the size of the cache is at least as large as the number of items we're storing
+		cache, err := NewAutoRefreshCache(syncFakeItem, rateLimiter, testResyncPeriod, 10, nil)
+		assert.NoError(t, err)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	cache.Start(ctx)
+		ctx, cancel := context.WithCancel(context.Background())
+		cache.Start(ctx)
 
-	// create
-	_, err := cache.GetOrCreate(item)
-	assert.NoError(t, err, "unexpected GetOrCreate failure")
+		// Create ten items in the cache
+		for i := 1; i <= 10; i++ {
+			cache.GetOrCreate(fakeCacheItem{
+				id:  fmt.Sprintf("%d", i),
+				val: 0,
+			})
+		}
 
-	// synced?
-	item.moveNext()
-	m := cache.Get(item.ID()).(*testCacheItem)
-	assert.Equal(t, 1, m.val)
+		// Wait half a second for all resync periods to complete
+		time.Sleep(500 * time.Millisecond)
+		for i := 1; i <= 10; i++ {
+			item := cache.Get(fmt.Sprintf("%d", i))
+			assert.Equal(t, 10, item.(fakeCacheItem).val)
+		}
+		cancel()
+	})
 
-	// synced again?
-	item.moveNext()
-	m = cache.Get(item.ID()).(*testCacheItem)
-	assert.Equal(t, 2, m.val)
+	t.Run("deleting objects from cache", func(t *testing.T) {
+		// the size of the cache is at least as large as the number of items we're storing
+		cache, err := NewAutoRefreshCache(syncFakeItemAlwaysDelete, rateLimiter, testResyncPeriod, 10, nil)
+		assert.NoError(t, err)
 
-	// removed?
-	item.moveNext()
-	currentSyncCount := item.synced.Load()
-	item.deleted.Store(true)
-	for currentSyncCount == item.synced.Load() {
-		time.Sleep(testResyncPeriod * 5) // spare enough time to process remove!
-	}
+		ctx, cancel := context.WithCancel(context.Background())
+		cache.Start(ctx)
 
-	time.Sleep(testResyncPeriod * 10) // spare enough time to process remove!
+		// Create ten items in the cache
+		for i := 1; i <= 10; i++ {
+			cache.GetOrCreate(fakeCacheItem{
+				id:  fmt.Sprintf("%d", i),
+				val: 0,
+			})
+		}
 
-	val := cache.Get(item.ID())
-
-	assert.Nil(t, val)
-	cancel()
-}
-
-func TestCacheContextCancel(t *testing.T) {
-	testResyncPeriod := time.Millisecond
-	rateLimiter := NewRateLimiter("mockLimiter", 10000, 1)
-
-	item := &testAutoIncrementItem{val: 0}
-	cache := NewAutoRefreshCache(item.syncItem, rateLimiter, testResyncPeriod)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	cache.Start(ctx)
-	_, err := cache.GetOrCreate(item)
-	assert.NoError(t, err, "failed to add item to cache")
-	time.Sleep(testResyncPeriod * 10) // spare enough time to process remove!
-	cancel()
-
-	// Get item
-	m, err := cache.GetOrCreate(item)
-	val1 := m.(*testAutoIncrementItem).val
-	assert.NoError(t, err, "unexpected GetOrCreate failure")
-
-	// wait a few more resync periods and check that nothings has changed as auto-refresh is stopped
-	time.Sleep(testResyncPeriod * 20)
-	val2 := m.(*testAutoIncrementItem).val
-	assert.Equal(t, val1, val2)
+		// Wait for all resync periods to complete
+		time.Sleep(50 * time.Millisecond)
+		for i := 1; i <= 10; i++ {
+			obj := cache.Get(fmt.Sprintf("%d", i))
+			assert.Nil(t, obj)
+		}
+		cancel()
+	})
 }

--- a/utils/auto_refresh_cache_test.go
+++ b/utils/auto_refresh_cache_test.go
@@ -3,9 +3,10 @@ package utils
 import (
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const fakeCacheItemValueLimit = 10
@@ -29,11 +30,6 @@ func syncFakeItem(_ context.Context, obj CacheItem) (CacheItem, CacheSyncAction,
 	return fakeCacheItem{id: item.ID(), val: item.val + 1}, Update, nil
 }
 
-func syncFakeItemLagged(ctx context.Context, obj CacheItem) (CacheItem, CacheSyncAction, error) {
-	time.Sleep(100 * time.Millisecond)
-	return syncFakeItem(ctx, obj)
-}
-
 func syncFakeItemAlwaysDelete(_ context.Context, obj CacheItem) (CacheItem, CacheSyncAction, error) {
 	return obj, Delete, nil
 }
@@ -52,10 +48,11 @@ func TestCacheTwo(t *testing.T) {
 
 		// Create ten items in the cache
 		for i := 1; i <= 10; i++ {
-			cache.GetOrCreate(fakeCacheItem{
+			_, err := cache.GetOrCreate(fakeCacheItem{
 				id:  fmt.Sprintf("%d", i),
 				val: 0,
 			})
+			assert.NoError(t, err)
 		}
 
 		// Wait half a second for all resync periods to complete
@@ -77,10 +74,11 @@ func TestCacheTwo(t *testing.T) {
 
 		// Create ten items in the cache
 		for i := 1; i <= 10; i++ {
-			cache.GetOrCreate(fakeCacheItem{
+			_, err = cache.GetOrCreate(fakeCacheItem{
 				id:  fmt.Sprintf("%d", i),
 				val: 0,
 			})
+			assert.NoError(t, err)
 		}
 
 		// Wait for all resync periods to complete


### PR DESCRIPTION
This changes the backing data store behind the AutoRefreshCache which some of the Flyte engine plugins use from a `sync.Map` to an [LRU cache](https://github.com/hashicorp/golang-lru) (released under Mozilla Public License 2.0).

* If supplied with a Prometheus metrics scope, a counter will be created for evictions.  The rate at which counter increases can be used to gauge how poorly the cache is performing - if the rate of evictions is ~ the rate of GetOrCreate calls then something is amiss.
* Heavily modified the unit test, but they're still only cursory.  Open to suggestions on how to do more testing.
