### PR TITLE
Flinkk8soperator needs Log writer to be passed to Resty

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -5,6 +5,7 @@ package logger
 
 import (
 	"context"
+	"io"
 
 	"github.com/lyft/flytestdlib/contextutils"
 
@@ -79,6 +80,11 @@ func getLogger(ctx context.Context) logrus.FieldLogger {
 	entry.Level = logrus.Level(cfg.Level)
 
 	return entry
+}
+
+func GetLogWriter(ctx context.Context) *io.PipeWriter {
+	logger := getLogger(ctx)
+	return logger.(*logrus.Entry).Writer()
 }
 
 func WithIndent(ctx context.Context, additionalIndent string) context.Context {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -82,6 +82,7 @@ func getLogger(ctx context.Context) logrus.FieldLogger {
 	return entry
 }
 
+// Returns a PipeWriter that can be passed used to other libraries for logging
 func GetLogWriter(ctx context.Context) *io.PipeWriter {
 	logger := getLogger(ctx)
 	return logger.(*logrus.Entry).Writer()

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -82,7 +82,7 @@ func getLogger(ctx context.Context) logrus.FieldLogger {
 	return entry
 }
 
-// Returns a PipeWriter that can be passed used to other libraries for logging
+// Returns a standard io.PipeWriter that logs using the same logger configurations in this package.
 func GetLogWriter(ctx context.Context) *io.PipeWriter {
 	logger := getLogger(ctx)
 	return logger.(*logrus.Entry).Writer()


### PR DESCRIPTION
Flink operator uses https://github.com/go-resty/resty to communicate to Job manager. Resty call logs do not follow the logger settings.

If flytestdlib logger can expose writer, I can pass it in to resty.SetLogger(..)

Alternatively we can expose GetLogger if you think that is better.