### PR TITLE
Add lp as an optional label for stats

### DIFF
--- a/contextutils/context.go
+++ b/contextutils/context.go
@@ -39,6 +39,7 @@ var logKeys = []Key{
 	TaskTypeKey,
 	PhaseKey,
 	RoutineLabelKey,
+	LaunchPlanIDKey,
 }
 
 // Gets a new context with namespace set.

--- a/contextutils/context.go
+++ b/contextutils/context.go
@@ -22,6 +22,7 @@ const (
 	JobIDKey        Key = "job_id"
 	PhaseKey        Key = "phase"
 	RoutineLabelKey Key = "routine"
+	LaunchPlanIDKey Key = "lp"
 )
 
 func (k Key) String() string {
@@ -83,6 +84,11 @@ func WithNodeID(ctx context.Context, nodeID string) context.Context {
 // Gets a new context with WorkflowName set.
 func WithWorkflowID(ctx context.Context, workflow string) context.Context {
 	return context.WithValue(ctx, WorkflowIDKey, workflow)
+}
+
+// Gets a new context with a launch plan ID set.
+func WithLaunchPlanID(ctx context.Context, launch_plan string) context.Context {
+	return context.WithValue(ctx, LaunchPlanIDKey, launch_plan)
 }
 
 // Get new context with Project and Domain values set

--- a/contextutils/context.go
+++ b/contextutils/context.go
@@ -87,8 +87,8 @@ func WithWorkflowID(ctx context.Context, workflow string) context.Context {
 }
 
 // Gets a new context with a launch plan ID set.
-func WithLaunchPlanID(ctx context.Context, launch_plan string) context.Context {
-	return context.WithValue(ctx, LaunchPlanIDKey, launch_plan)
+func WithLaunchPlanID(ctx context.Context, launchPlan string) context.Context {
+	return context.WithValue(ctx, LaunchPlanIDKey, launchPlan)
 }
 
 // Get new context with Project and Domain values set

--- a/contextutils/context_test.go
+++ b/contextutils/context_test.go
@@ -69,6 +69,13 @@ func TestWithWorkflowID(t *testing.T) {
 	assert.Equal(t, "flyte", ctx.Value(WorkflowIDKey))
 }
 
+func TestWithLaunchPlanID(t *testing.T) {
+	ctx := context.Background()
+	assert.Nil(t, ctx.Value(LaunchPlanIDKey))
+	ctx = WithLaunchPlanID(ctx, "flytelp")
+	assert.Equal(t, "flytelp", ctx.Value(LaunchPlanIDKey))
+}
+
 func TestWithNodeID(t *testing.T) {
 	ctx := context.Background()
 	assert.Nil(t, ctx.Value(NodeIDKey))

--- a/promutils/labeled/counter_test.go
+++ b/promutils/labeled/counter_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestLabeledCounter(t *testing.T) {
+	UnsetMetricKeys()
 	assert.NotPanics(t, func() {
 		SetMetricKeys(contextutils.ProjectKey, contextutils.DomainKey, contextutils.WorkflowIDKey, contextutils.TaskIDKey, contextutils.LaunchPlanIDKey)
 	})

--- a/promutils/labeled/counter_test.go
+++ b/promutils/labeled/counter_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestLabeledCounter(t *testing.T) {
 	assert.NotPanics(t, func() {
-		SetMetricKeys(contextutils.ProjectKey, contextutils.DomainKey, contextutils.WorkflowIDKey, contextutils.TaskIDKey)
+		SetMetricKeys(contextutils.ProjectKey, contextutils.DomainKey, contextutils.WorkflowIDKey, contextutils.TaskIDKey, contextutils.LaunchPlanIDKey)
 	})
 
 	scope := promutils.NewTestScope()
@@ -26,6 +26,10 @@ func TestLabeledCounter(t *testing.T) {
 	c.Add(ctx, 1.0)
 
 	ctx = contextutils.WithTaskID(ctx, "task")
+	c.Inc(ctx)
+	c.Add(ctx, 1.0)
+
+	ctx = contextutils.WithLaunchPlanID(ctx, "lp")
 	c.Inc(ctx)
 	c.Add(ctx, 1.0)
 }

--- a/promutils/labeled/keys.go
+++ b/promutils/labeled/keys.go
@@ -15,11 +15,11 @@ var (
 
 	// Metric Keys to label metrics with. These keys get pulled from context if they are present. Use contextutils to fill
 	// them in.
-	metricKeys = make([]contextutils.Key, 0)
+	metricKeys []contextutils.Key
 
 	// :(, we have to create a separate list to satisfy the MustNewCounterVec API as it accepts string only
-	metricStringKeys = make([]string, 0)
-	metricKeysAreSet = sync.Once{}
+	metricStringKeys []string
+	metricKeysAreSet sync.Once
 )
 
 // Sets keys to use with labeled metrics. The values of these keys will be pulled from context at runtime.
@@ -44,4 +44,15 @@ func SetMetricKeys(keys ...contextutils.Key) {
 
 func GetUnlabeledMetricName(metricName string) string {
 	return metricName + "_unlabeled"
+}
+
+// Warning: This function is not thread safe and should be used for testing only outside of this package.
+func UnsetMetricKeys() {
+	metricKeys = make([]contextutils.Key, 0)
+	metricStringKeys = make([]string, 0)
+	metricKeysAreSet = sync.Once{}
+}
+
+func init() {
+	UnsetMetricKeys()
 }

--- a/promutils/labeled/keys_test.go
+++ b/promutils/labeled/keys_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestMetricKeys(t *testing.T) {
+	UnsetMetricKeys()
 	input := []contextutils.Key{
 		contextutils.ProjectKey, contextutils.DomainKey, contextutils.WorkflowIDKey, contextutils.TaskIDKey, contextutils.LaunchPlanIDKey,
 	}

--- a/promutils/labeled/keys_test.go
+++ b/promutils/labeled/keys_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestMetricKeys(t *testing.T) {
 	input := []contextutils.Key{
-		contextutils.ProjectKey, contextutils.DomainKey, contextutils.WorkflowIDKey, contextutils.TaskIDKey,
+		contextutils.ProjectKey, contextutils.DomainKey, contextutils.WorkflowIDKey, contextutils.TaskIDKey, contextutils.LaunchPlanIDKey,
 	}
 
 	assert.NotPanics(t, func() { SetMetricKeys(input...) })

--- a/promutils/labeled/stopwatch_test.go
+++ b/promutils/labeled/stopwatch_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestLabeledStopWatch(t *testing.T) {
+	UnsetMetricKeys()
 	assert.NotPanics(t, func() {
 		SetMetricKeys(contextutils.ProjectKey, contextutils.DomainKey, contextutils.WorkflowIDKey, contextutils.TaskIDKey)
 	})

--- a/storage/cached_rawstore_test.go
+++ b/storage/cached_rawstore_test.go
@@ -19,6 +19,7 @@ import (
 )
 
 func init() {
+	labeled.UnsetMetricKeys()
 	labeled.SetMetricKeys(contextutils.ProjectKey, contextutils.DomainKey, contextutils.WorkflowIDKey, contextutils.TaskIDKey)
 }
 

--- a/storage/cached_rawstore_test.go
+++ b/storage/cached_rawstore_test.go
@@ -18,12 +18,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func init() {
-	labeled.UnsetMetricKeys()
-	labeled.SetMetricKeys(contextutils.ProjectKey, contextutils.DomainKey, contextutils.WorkflowIDKey, contextutils.TaskIDKey)
-}
-
 func TestNewCachedStore(t *testing.T) {
+	resetMetricKeys()
 
 	t.Run("CachingDisabled", func(t *testing.T) {
 		testScope := promutils.NewTestScope()
@@ -49,6 +45,11 @@ func TestNewCachedStore(t *testing.T) {
 		assert.NotNil(t, cStore)
 		assert.NotNil(t, cStore.(*cachedRawStore).cache)
 	})
+}
+
+func resetMetricKeys() {
+	labeled.UnsetMetricKeys()
+	labeled.SetMetricKeys(contextutils.ProjectKey, contextutils.DomainKey, contextutils.WorkflowIDKey, contextutils.TaskIDKey)
 }
 
 func dummyCacheStore(t *testing.T, store RawStore, scope promutils.Scope) *cachedRawStore {
@@ -87,6 +88,7 @@ func (d *dummyStore) WriteRaw(ctx context.Context, reference DataReference, size
 }
 
 func TestCachedRawStore(t *testing.T) {
+	resetMetricKeys()
 	ctx := context.TODO()
 	k1 := DataReference("k1")
 	k2 := DataReference("k2")

--- a/utils/marshal_utils_test.go
+++ b/utils/marshal_utils_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes/struct"
+	structpb "github.com/golang/protobuf/ptypes/struct"
 )
 
 type SimpleType struct {


### PR DESCRIPTION
In building alarms and graphs on executions, it is not currently possible to different between executions started by different launch plans.  This is problematic for us in our functional tests because the launch plan ID is what differentiates beta and prod executions.  Likewise, this would make it difficult/impossible for users to alert on parameterized scheduled workflows.

This adds the necessary label context utils which will be used to set the launch plan context by Propeller.