### PR TITLE
It should be possible to create a bitset of size 0

### DIFF
--- a/bitarray/bitset.go
+++ b/bitarray/bitset.go
@@ -1,11 +1,13 @@
 package bitarray
 
 import (
+	"math"
 	"unsafe"
 )
 
 /* #nosec */
 const blockSize = uint(unsafe.Sizeof(Block(0))) * 8
+const blockSizeF = float64(blockSize)
 
 type Block uint32
 
@@ -68,6 +70,6 @@ func (s BitSet) DeepCopy() BitSet {
 // Initializes a new BitSet of the specified size.
 func NewBitSet(desiredCap uint) *BitSet {
 	// Create enough blocks to contain the number of intended bits.
-	a := make(BitSet, ((desiredCap-1)/blockSize)+1)
+	a := make(BitSet, int(math.Ceil(float64(desiredCap)/blockSizeF)))
 	return &a
 }

--- a/bitarray/bitset_test.go
+++ b/bitarray/bitset_test.go
@@ -57,4 +57,10 @@ func TestBitSet_Cap(t *testing.T) {
 		b := NewBitSet(blockSize*2 + 20)
 		assert.Equal(t, int(blockSize*3), int(b.Cap()))
 	})
+
+	t.Run("0", func(t *testing.T) {
+		b := NewBitSet(0)
+		assert.Equal(t, 0, int(b.Cap()))
+
+	})
 }


### PR DESCRIPTION
Currently, if the desired cap is 0, it results in a negative number. The expected algorithm is ceil of the desired capacity / block size