### PR TITLE
Fix separator used in UrlPath to '/' instead of OS-dependent path sep…

### DIFF
--- a/storage/url_path.go
+++ b/storage/url_path.go
@@ -3,11 +3,13 @@ package storage
 import (
 	"context"
 	"fmt"
-	"github.com/pkg/errors"
 	"strings"
 
-	"github.com/lyft/flytestdlib/logger"
+	"github.com/pkg/errors"
+
 	"net/url"
+
+	"github.com/lyft/flytestdlib/logger"
 )
 
 const separator = "/"

--- a/storage/url_path.go
+++ b/storage/url_path.go
@@ -3,26 +3,25 @@ package storage
 import (
 	"context"
 	"fmt"
-
 	"github.com/pkg/errors"
-
-	"net/url"
-	"os"
-	"path/filepath"
+	"strings"
 
 	"github.com/lyft/flytestdlib/logger"
+	"net/url"
 )
+
+const separator = "/"
 
 // Implements ReferenceConstructor that assumes paths are URL-compatible.
 type URLPathConstructor struct {
 }
 
 func ensureEndingPathSeparator(path DataReference) DataReference {
-	if len(path) > 0 && path[len(path)-1] == os.PathSeparator {
+	if len(path) > 0 && path[len(path)-1] == separator[0] {
 		return path
 	}
 
-	return path + "/"
+	return path + separator
 }
 
 func (URLPathConstructor) ConstructReference(ctx context.Context, reference DataReference, nestedKeys ...string) (DataReference, error) {
@@ -32,7 +31,9 @@ func (URLPathConstructor) ConstructReference(ctx context.Context, reference Data
 		return "", errors.Wrap(err, fmt.Sprintf("Reference is of an invalid format [%v]", reference))
 	}
 
-	rel, err := url.Parse(filepath.Join(nestedKeys...))
+	rel, err := url.Parse(strings.Join(MapStrings(func(s string) string {
+		return strings.Trim(s, separator)
+	}, nestedKeys...), separator))
 	if err != nil {
 		logger.Errorf(ctx, "Failed to parse nested keys: %v", reference)
 		return "", errors.Wrap(err, fmt.Sprintf("Reference is of an invalid format [%v]", reference))

--- a/storage/utils.go
+++ b/storage/utils.go
@@ -46,12 +46,12 @@ func IsFailedWriteToCache(err error) bool {
 }
 
 func MapStrings(mapper func(string) string, strings ...string) []string {
-	for i, str := range strings {
-		strings[i] = mapper(str)
-	}
-
 	if strings == nil {
 		return []string{}
+	}
+
+	for i, str := range strings {
+		strings[i] = mapper(str)
 	}
 
 	return strings

--- a/storage/utils.go
+++ b/storage/utils.go
@@ -44,3 +44,15 @@ func IsExceedsLimit(err error) bool {
 func IsFailedWriteToCache(err error) bool {
 	return errors2.IsCausedBy(err, ErrFailedToWriteCache)
 }
+
+func MapStrings(mapper func(string) string, strings ...string) []string {
+	for i, str := range strings {
+		strings[i] = mapper(str)
+	}
+
+	if strings == nil {
+		return []string{}
+	}
+
+	return strings
+}

--- a/storage/utils_test.go
+++ b/storage/utils_test.go
@@ -47,3 +47,29 @@ func TestIsFailedWriteToCache(t *testing.T) {
 	assert.True(t, IsFailedWriteToCache(failedToWriteCacheError))
 	assert.False(t, IsFailedWriteToCache(sysError))
 }
+
+func TestMapStrings(t *testing.T) {
+	t.Run("nothing", func(t *testing.T) {
+		assert.Equal(t, []string{}, MapStrings(func(s string) string {
+			return s
+		}))
+	})
+
+	t.Run("one item", func(t *testing.T) {
+		assert.Equal(t, []string{"item"}, MapStrings(func(s string) string {
+			return s
+		}, "item"))
+	})
+
+	t.Run("const", func(t *testing.T) {
+		assert.Equal(t, []string{"something"}, MapStrings(func(s string) string {
+			return "something"
+		}, "item"))
+	})
+
+	t.Run("half string", func(t *testing.T) {
+		assert.Equal(t, []string{"thing", "some"}, MapStrings(func(s string) string {
+			return s[len(s)/2:]
+		}, "something", "somesome"))
+	})
+}


### PR DESCRIPTION
…arator

UrlPathConstructor is the default ReferenceConstructor used in all DataStores. This is used to construct store urls "s3://<bucket>/prefix/key/key"

This implementation should not rely on the underlying system to build these URLs. The format and character set is defined by the storage providers (s3, azure, gcs... etc.). Hence why this change should remove such dependency.