### PR TITLE
support regexp config

### DIFF
--- a/config/regexp.go
+++ b/config/regexp.go
@@ -1,0 +1,41 @@
+package config
+
+import (
+	"encoding/json"
+	"errors"
+	"regexp"
+)
+
+// A regexp.Regexp wrapper that can marshal and unmarshal into simple regexp string.
+type Regexp struct {
+	regexp.Regexp
+}
+
+func (r Regexp) MarshalJSON() ([]byte, error) {
+	return json.Marshal(r.String())
+}
+
+func (r *Regexp) UnmarshalJSON(b []byte) error {
+	if len(b) == 0 {
+		r.Regexp = regexp.Regexp{}
+		return nil
+	}
+
+	var v interface{}
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+
+	switch value := v.(type) {
+	case string:
+		rc, err := regexp.Compile(value)
+		if err != nil {
+			return err
+		}
+
+		r.Regexp = *rc
+		return nil
+	default:
+		return errors.New("invalid regexp")
+	}
+}

--- a/config/regexp_test.go
+++ b/config/regexp_test.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/lyft/flytestdlib/internal/utils"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegexp_MarshalJSON(t *testing.T) {
+	validRegexps := []string{
+		"",
+		".*",
+		"^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}$",
+	}
+
+	for i, validRegexp := range validRegexps {
+		t.Run(fmt.Sprintf("Valid %v", i), func(t *testing.T) {
+			expected := Regexp{Regexp: utils.MustCompileRegexp(validRegexp)}
+
+			b, err := expected.MarshalJSON()
+			assert.NoError(t, err)
+
+			actual := Regexp{}
+			err = actual.UnmarshalJSON(b)
+			assert.NoError(t, err)
+
+			assert.True(t, reflect.DeepEqual(expected, actual))
+		})
+	}
+}
+
+func TestRegexp_UnmarshalJSON(t *testing.T) {
+	invalidValues := []interface{}{
+		"^(",
+		123,
+		true,
+	}
+	for i, invalidRegexp := range invalidValues {
+		t.Run(fmt.Sprintf("Invalid %v", i), func(t *testing.T) {
+			raw, err := json.Marshal(invalidRegexp)
+			assert.NoError(t, err)
+
+			actual := Regexp{}
+			err = actual.UnmarshalJSON(raw)
+			assert.Error(t, err)
+		})
+	}
+
+	t.Run("Empty regexp", func(t *testing.T) {
+		expected := Regexp{}
+
+		actual := Regexp{}
+		err := actual.UnmarshalJSON([]byte{})
+		assert.NoError(t, err)
+		assert.True(t, reflect.DeepEqual(expected, actual))
+	})
+}

--- a/internal/utils/parsers.go
+++ b/internal/utils/parsers.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"net/url"
+	"regexp"
 )
 
 // A utility function to be used in tests. It parses urlString as url.URL or panics if it's invalid.
@@ -17,4 +18,14 @@ func MustParseURL(urlString string) url.URL {
 // A utility function to be used in tests. It returns the address of the passed value.
 func RefInt(val int) *int {
 	return &val
+}
+
+// A utility function to be used in tests. It compiles regexpString as regexp.Regexp or panics if it's invalid.
+func MustCompileRegexp(regexpString string) regexp.Regexp {
+	r, err := regexp.Compile(regexpString)
+	if err != nil {
+		panic(err)
+	}
+
+	return *r
 }

--- a/internal/utils/parsers_test.go
+++ b/internal/utils/parsers_test.go
@@ -23,3 +23,15 @@ func TestRefUint32(t *testing.T) {
 	res := RefInt(input)
 	assert.Equal(t, input, *res)
 }
+
+func TestMustCompileRegexp(t *testing.T) {
+	t.Run("Valid regexp", func(t *testing.T) {
+		MustCompileRegexp("^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}$")
+	})
+
+	t.Run("Invalid regexp", func(t *testing.T) {
+		assert.Panics(t, func() {
+			MustCompileRegexp("^(")
+		})
+	})
+}


### PR DESCRIPTION
# TL;DR
Provide `regexp` config type so user can do for example:
```
...
filter    config.Regexp
...
```

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
As commented https://github.com/lyft/flytepropeller/pull/90#discussion_r393109951, it is better to have an dedicated `regexp` config type so validation can be done properly and early on.

https://github.com/lyft/flytepropeller/pull/90 Might not be needed after all, but having such a type may still make sense.

## Tracking Issue
NA

## Follow-up issue
NA