### PR TITLE
Add a failure type label to failure metrics in storage package

### DIFF
--- a/contextutils/context.go
+++ b/contextutils/context.go
@@ -44,6 +44,17 @@ var logKeys = []Key{
 	ResourceVersionKey,
 }
 
+// MetricKeysFromStrings is a convenience method to convert a slice of strings into a slice of Keys
+func MetricKeysFromStrings(keys []string) []Key {
+	res := make([]Key, 0, len(keys))
+
+	for _, k := range keys {
+		res = append(res, Key(k))
+	}
+
+	return res
+}
+
 // Gets a new context with the resource version set.
 func WithResourceVersion(ctx context.Context, resourceVersion string) context.Context {
 	return context.WithValue(ctx, ResourceVersionKey, resourceVersion)

--- a/promutils/labeled/metric_option.go
+++ b/promutils/labeled/metric_option.go
@@ -13,3 +13,9 @@ type EmitUnlabeledMetricOption struct {
 func (EmitUnlabeledMetricOption) isMetricOption() {}
 
 var EmitUnlabeledMetric = EmitUnlabeledMetricOption{}
+
+type AdditionalLabelsOption struct {
+	Labels []string
+}
+
+func (AdditionalLabelsOption) isMetricOption() {}

--- a/promutils/labeled/metric_option.go
+++ b/promutils/labeled/metric_option.go
@@ -14,7 +14,10 @@ func (EmitUnlabeledMetricOption) isMetricOption() {}
 
 var EmitUnlabeledMetric = EmitUnlabeledMetricOption{}
 
+// AdditionalLabelsOption instructs the labeled metric to expect additional labels scoped for this just this metric
+// in the context passed.
 type AdditionalLabelsOption struct {
+	// A collection of labels to look for in the passed context.
 	Labels []string
 }
 

--- a/storage/stow_store.go
+++ b/storage/stow_store.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"time"
 
+	"github.com/lyft/flytestdlib/contextutils"
+
 	"github.com/lyft/flytestdlib/promutils/labeled"
 
 	"github.com/lyft/flytestdlib/errors"
@@ -16,7 +18,7 @@ import (
 )
 
 const (
-	FailureTypeLabel = "failure_type"
+	FailureTypeLabel contextutils.Key = "failure_type"
 )
 
 type stowMetrics struct {
@@ -159,7 +161,7 @@ func (s *StowStore) GetBaseContainerFQN(ctx context.Context) DataReference {
 }
 
 func NewStowRawStore(containerBaseFQN DataReference, container stow.Container, metricsScope promutils.Scope) (*StowStore, error) {
-	failureTypeOption := labeled.AdditionalLabelsOption{Labels: []string{FailureTypeLabel}}
+	failureTypeOption := labeled.AdditionalLabelsOption{Labels: []string{FailureTypeLabel.String()}}
 	self := &StowStore{
 		Container:        container,
 		containerBaseFQN: containerBaseFQN,

--- a/storage/stow_store.go
+++ b/storage/stow_store.go
@@ -5,9 +5,9 @@ import (
 	"io"
 	"time"
 
-	"github.com/lyft/flytestdlib/errors"
+	"github.com/lyft/flytestdlib/promutils/labeled"
 
-	"github.com/prometheus/client_golang/prometheus"
+	"github.com/lyft/flytestdlib/errors"
 
 	"github.com/lyft/flytestdlib/promutils"
 
@@ -15,18 +15,22 @@ import (
 	errs "github.com/pkg/errors"
 )
 
+const (
+	FailureTypeLabel = "failure_type"
+)
+
 type stowMetrics struct {
-	BadReference prometheus.Counter
-	BadContainer prometheus.Counter
+	BadReference labeled.Counter
+	BadContainer labeled.Counter
 
-	HeadFailure prometheus.Counter
-	HeadLatency promutils.StopWatch
+	HeadFailure labeled.Counter
+	HeadLatency labeled.StopWatch
 
-	ReadFailure     prometheus.Counter
-	ReadOpenLatency promutils.StopWatch
+	ReadFailure     labeled.Counter
+	ReadOpenLatency labeled.StopWatch
 
-	WriteFailure prometheus.Counter
-	WriteLatency promutils.StopWatch
+	WriteFailure labeled.Counter
+	WriteLatency labeled.StopWatch
 }
 
 // Implements DataStore to talk to stow location store.
@@ -50,9 +54,9 @@ func (s StowMetadata) Exists() bool {
 	return s.exists
 }
 
-func (s *StowStore) getContainer(container string) (c stow.Container, err error) {
+func (s *StowStore) getContainer(ctx context.Context, container string) (c stow.Container, err error) {
 	if s.Container.Name() != container {
-		s.metrics.BadContainer.Inc()
+		s.metrics.BadContainer.Inc(ctx)
 		return nil, errs.Wrapf(stow.ErrNotFound, "Conf container:%v != Passed Container:%v", s.Container.Name(), container)
 	}
 
@@ -62,16 +66,16 @@ func (s *StowStore) getContainer(container string) (c stow.Container, err error)
 func (s *StowStore) Head(ctx context.Context, reference DataReference) (Metadata, error) {
 	_, c, k, err := reference.Split()
 	if err != nil {
-		s.metrics.BadReference.Inc()
+		s.metrics.BadReference.Inc(ctx)
 		return nil, err
 	}
 
-	container, err := s.getContainer(c)
+	container, err := s.getContainer(ctx, c)
 	if err != nil {
 		return nil, err
 	}
 
-	t := s.metrics.HeadLatency.Start()
+	t := s.metrics.HeadLatency.Start(ctx)
 	item, err := container.Item(k)
 	if err == nil {
 		if _, err = item.Metadata(); err == nil {
@@ -85,29 +89,31 @@ func (s *StowStore) Head(ctx context.Context, reference DataReference) (Metadata
 			}
 		}
 	}
-	s.metrics.HeadFailure.Inc()
+
 	if IsNotFound(err) {
 		return StowMetadata{exists: false}, nil
 	}
+
+	incFailureCounterForError(ctx, s.metrics.HeadFailure, err)
 	return StowMetadata{exists: false}, errs.Wrapf(err, "path:%v", k)
 }
 
 func (s *StowStore) ReadRaw(ctx context.Context, reference DataReference) (io.ReadCloser, error) {
 	_, c, k, err := reference.Split()
 	if err != nil {
-		s.metrics.BadReference.Inc()
+		s.metrics.BadReference.Inc(ctx)
 		return nil, err
 	}
 
-	container, err := s.getContainer(c)
+	container, err := s.getContainer(ctx, c)
 	if err != nil {
 		return nil, err
 	}
 
-	t := s.metrics.ReadOpenLatency.Start()
+	t := s.metrics.ReadOpenLatency.Start(ctx)
 	item, err := container.Item(k)
 	if err != nil {
-		s.metrics.ReadFailure.Inc()
+		incFailureCounterForError(ctx, s.metrics.ReadFailure, err)
 		return nil, err
 	}
 	t.Stop()
@@ -127,21 +133,22 @@ func (s *StowStore) ReadRaw(ctx context.Context, reference DataReference) (io.Re
 func (s *StowStore) WriteRaw(ctx context.Context, reference DataReference, size int64, opts Options, raw io.Reader) error {
 	_, c, k, err := reference.Split()
 	if err != nil {
-		s.metrics.BadReference.Inc()
+		s.metrics.BadReference.Inc(ctx)
 		return err
 	}
 
-	container, err := s.getContainer(c)
+	container, err := s.getContainer(ctx, c)
 	if err != nil {
 		return err
 	}
 
-	t := s.metrics.WriteLatency.Start()
+	t := s.metrics.WriteLatency.Start(ctx)
 	_, err = container.Put(k, raw, size, opts.Metadata)
 	if err != nil {
-		s.metrics.WriteFailure.Inc()
+		incFailureCounterForError(ctx, s.metrics.WriteFailure, err)
 		return errs.Wrapf(err, "Failed to write data [%vb] to path [%v].", size, k)
 	}
+
 	t.Stop()
 
 	return nil
@@ -152,21 +159,22 @@ func (s *StowStore) GetBaseContainerFQN(ctx context.Context) DataReference {
 }
 
 func NewStowRawStore(containerBaseFQN DataReference, container stow.Container, metricsScope promutils.Scope) (*StowStore, error) {
+	failureTypeOption := labeled.AdditionalLabelsOption{Labels: []string{FailureTypeLabel}}
 	self := &StowStore{
 		Container:        container,
 		containerBaseFQN: containerBaseFQN,
 		metrics: &stowMetrics{
-			BadReference: metricsScope.MustNewCounter("bad_key", "Indicates the provided storage reference/key is incorrectly formatted"),
-			BadContainer: metricsScope.MustNewCounter("bad_container", "Indicates request for a container that has not been initialized"),
+			BadReference: labeled.NewCounter("bad_key", "Indicates the provided storage reference/key is incorrectly formatted", metricsScope, labeled.EmitUnlabeledMetric),
+			BadContainer: labeled.NewCounter("bad_container", "Indicates request for a container that has not been initialized", metricsScope, labeled.EmitUnlabeledMetric),
 
-			HeadFailure: metricsScope.MustNewCounter("head_failure", "Indicates failure in HEAD for a given reference"),
-			HeadLatency: metricsScope.MustNewStopWatch("head", "Indicates time to fetch metadata using the Head API", time.Millisecond),
+			HeadFailure: labeled.NewCounter("head_failure", "Indicates failure in HEAD for a given reference", metricsScope, labeled.EmitUnlabeledMetric),
+			HeadLatency: labeled.NewStopWatch("head", "Indicates time to fetch metadata using the Head API", time.Millisecond, metricsScope, labeled.EmitUnlabeledMetric),
 
-			ReadFailure:     metricsScope.MustNewCounter("read_failure", "Indicates failure in GET for a given reference"),
-			ReadOpenLatency: metricsScope.MustNewStopWatch("read_open", "Indicates time to first byte when reading", time.Millisecond),
+			ReadFailure:     labeled.NewCounter("read_failure", "Indicates failure in GET for a given reference", metricsScope, labeled.EmitUnlabeledMetric, failureTypeOption),
+			ReadOpenLatency: labeled.NewStopWatch("read_open", "Indicates time to first byte when reading", time.Millisecond, metricsScope, labeled.EmitUnlabeledMetric),
 
-			WriteFailure: metricsScope.MustNewCounter("write_failure", "Indicates failure in storing/PUT for a given reference"),
-			WriteLatency: metricsScope.MustNewStopWatch("write", "Time to write an object irrespective of size", time.Millisecond),
+			WriteFailure: labeled.NewCounter("write_failure", "Indicates failure in storing/PUT for a given reference", metricsScope, labeled.EmitUnlabeledMetric, failureTypeOption),
+			WriteLatency: labeled.NewStopWatch("write", "Time to write an object irrespective of size", time.Millisecond, metricsScope, labeled.EmitUnlabeledMetric),
 		},
 	}
 

--- a/storage/utils.go
+++ b/storage/utils.go
@@ -16,6 +16,10 @@ var (
 	ErrFailedToWriteCache stdErrs.ErrorCode = "CACHE_WRITE_FAILED"
 )
 
+const (
+	genericFailureTypeLabel = "Generic"
+)
+
 // Gets a value indicating whether the underlying error is a Not Found error.
 func IsNotFound(err error) bool {
 	if root := errors.Cause(err); os.IsNotExist(root) {
@@ -64,6 +68,6 @@ func incFailureCounterForError(ctx context.Context, counter labeled.Counter, err
 	if found {
 		counter.Inc(context.WithValue(ctx, FailureTypeLabel, errCode))
 	} else {
-		counter.Inc(context.WithValue(ctx, FailureTypeLabel, "Generic"))
+		counter.Inc(context.WithValue(ctx, FailureTypeLabel, genericFailureTypeLabel))
 	}
 }

--- a/storage/utils.go
+++ b/storage/utils.go
@@ -1,17 +1,19 @@
 package storage
 
 import (
+	"context"
 	"os"
 
-	errors2 "github.com/lyft/flytestdlib/errors"
+	stdErrs "github.com/lyft/flytestdlib/errors"
+	"github.com/lyft/flytestdlib/promutils/labeled"
 
 	"github.com/graymeta/stow"
 	"github.com/pkg/errors"
 )
 
 var (
-	ErrExceedsLimit       errors2.ErrorCode = "LIMIT_EXCEEDED"
-	ErrFailedToWriteCache errors2.ErrorCode = "CACHE_WRITE_FAILED"
+	ErrExceedsLimit       stdErrs.ErrorCode = "LIMIT_EXCEEDED"
+	ErrFailedToWriteCache stdErrs.ErrorCode = "CACHE_WRITE_FAILED"
 )
 
 // Gets a value indicating whether the underlying error is a Not Found error.
@@ -20,7 +22,7 @@ func IsNotFound(err error) bool {
 		return true
 	}
 
-	if errors2.IsCausedByError(err, stow.ErrNotFound) {
+	if stdErrs.IsCausedByError(err, stow.ErrNotFound) {
 		return true
 	}
 
@@ -38,11 +40,11 @@ func IsExists(err error) bool {
 
 // Gets a value indicating whether the root cause of error is a "limit exceeded" error.
 func IsExceedsLimit(err error) bool {
-	return errors2.IsCausedBy(err, ErrExceedsLimit)
+	return stdErrs.IsCausedBy(err, ErrExceedsLimit)
 }
 
 func IsFailedWriteToCache(err error) bool {
-	return errors2.IsCausedBy(err, ErrFailedToWriteCache)
+	return stdErrs.IsCausedBy(err, ErrFailedToWriteCache)
 }
 
 func MapStrings(mapper func(string) string, strings ...string) []string {
@@ -55,4 +57,13 @@ func MapStrings(mapper func(string) string, strings ...string) []string {
 	}
 
 	return strings
+}
+
+func incFailureCounterForError(ctx context.Context, counter labeled.Counter, err error) {
+	errCode, found := stdErrs.GetErrorCode(err)
+	if found {
+		counter.Inc(context.WithValue(ctx, FailureTypeLabel, errCode))
+	} else {
+		counter.Inc(context.WithValue(ctx, FailureTypeLabel, "Generic"))
+	}
 }


### PR DESCRIPTION
# TL;DR
Adds failure type as a tag on head, read and write failures emitted by storage package.

## Type
 - [ ] Bug Fix
 - [X] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [ ] Unit tests added
 - [X] Code documentation added
 - [X] Any pending items have an associated Issue

## Complete description
Added support in labeled package for adding additional labels on metrics then used that in storage package.

## Tracking Issue
https://github.com/lyft/flyte/issues/216

## Follow-up issue
_NA_