### PR TITLE
Add additional labels if present

### DIFF
--- a/promutils/labeled/counter.go
+++ b/promutils/labeled/counter.go
@@ -20,7 +20,7 @@ type Counter struct {
 // Inc increments the counter by 1. Use Add to increment it by arbitrary non-negative values. The data point will be
 // labeled with values from context. See labeled.SetMetricsKeys for information about to configure that.
 func (c Counter) Inc(ctx context.Context) {
-	counter, err := c.CounterVec.GetMetricWith(contextutils.Values(ctx, metricKeys...))
+	counter, err := c.CounterVec.GetMetricWith(contextutils.Values(ctx, append(metricKeys, c.additionalLabels...)...))
 	if err != nil {
 		panic(err.Error())
 	}

--- a/promutils/labeled/gauge.go
+++ b/promutils/labeled/gauge.go
@@ -19,7 +19,7 @@ type Gauge struct {
 // Inc increments the gauge by 1. Use Add to increment by arbitrary values. The data point will be
 // labeled with values from context. See labeled.SetMetricsKeys for information about to configure that.
 func (g Gauge) Inc(ctx context.Context) {
-	gauge, err := g.GaugeVec.GetMetricWith(contextutils.Values(ctx, metricKeys...))
+	gauge, err := g.GaugeVec.GetMetricWith(contextutils.Values(ctx, append(metricKeys, g.additionalLabels...)...))
 	if err != nil {
 		panic(err.Error())
 	}
@@ -33,7 +33,7 @@ func (g Gauge) Inc(ctx context.Context) {
 // Add adds the given value to the Gauge. (The value can be negative, resulting in a decrease of the Gauge.)
 // The data point will be labeled with values from context. See labeled.SetMetricsKeys for information about to configure that.
 func (g Gauge) Add(ctx context.Context, v float64) {
-	gauge, err := g.GaugeVec.GetMetricWith(contextutils.Values(ctx, metricKeys...))
+	gauge, err := g.GaugeVec.GetMetricWith(contextutils.Values(ctx, append(metricKeys, g.additionalLabels...)...))
 	if err != nil {
 		panic(err.Error())
 	}
@@ -47,7 +47,7 @@ func (g Gauge) Add(ctx context.Context, v float64) {
 // Set sets the Gauge to an arbitrary value.
 // The data point will be labeled with values from context. See labeled.SetMetricsKeys for information about to configure that.
 func (g Gauge) Set(ctx context.Context, v float64) {
-	gauge, err := g.GaugeVec.GetMetricWith(contextutils.Values(ctx, metricKeys...))
+	gauge, err := g.GaugeVec.GetMetricWith(contextutils.Values(ctx, append(metricKeys, g.additionalLabels...)...))
 	if err != nil {
 		panic(err.Error())
 	}
@@ -61,7 +61,7 @@ func (g Gauge) Set(ctx context.Context, v float64) {
 // Dec decrements the level by 1. Use Sub to decrement by arbitrary values. The data point will be
 // labeled with values from context. See labeled.SetMetricsKeys for information about to configure that.
 func (g Gauge) Dec(ctx context.Context) {
-	gauge, err := g.GaugeVec.GetMetricWith(contextutils.Values(ctx, metricKeys...))
+	gauge, err := g.GaugeVec.GetMetricWith(contextutils.Values(ctx, append(metricKeys, g.additionalLabels...)...))
 	if err != nil {
 		panic(err.Error())
 	}
@@ -75,7 +75,7 @@ func (g Gauge) Dec(ctx context.Context) {
 // Sub adds the given value to the Gauge. The value can be negative, resulting in an increase of the Gauge.
 // The data point will be labeled with values from context. See labeled.SetMetricsKeys for information about to configure that.
 func (g Gauge) Sub(ctx context.Context, v float64) {
-	gauge, err := g.GaugeVec.GetMetricWith(contextutils.Values(ctx, metricKeys...))
+	gauge, err := g.GaugeVec.GetMetricWith(contextutils.Values(ctx, append(metricKeys, g.additionalLabels...)...))
 	if err != nil {
 		panic(err.Error())
 	}

--- a/promutils/labeled/gauge_test.go
+++ b/promutils/labeled/gauge_test.go
@@ -94,32 +94,32 @@ func TestWithAdditionalLabels(t *testing.T) {
 	ctx = context.WithValue(ctx, bearingKey, "123")
 	g.Set(ctx, 42)
 	expected = `
-	   testscope:unittest{bearing="", domain="dev",lp="",project="flyte",task="",wf=""} 1
-       testscope:unittest{bearing="123", domain="dev",lp="",project="flyte",task="",wf=""} 42
+		testscope:unittest{bearing="", domain="dev",lp="",project="flyte",task="",wf=""} 1
+		testscope:unittest{bearing="123", domain="dev",lp="",project="flyte",task="",wf=""} 42
 	`
 	err = testutil.CollectAndCompare(g.GaugeVec, strings.NewReader(header+expected))
 	assert.NoError(t, err)
 
 	g.Add(ctx, 1)
 	expected = `
-	   testscope:unittest{bearing="", domain="dev",lp="",project="flyte",task="",wf=""} 1
-       testscope:unittest{bearing="123", domain="dev",lp="",project="flyte",task="",wf=""} 43
+		testscope:unittest{bearing="", domain="dev",lp="",project="flyte",task="",wf=""} 1
+		testscope:unittest{bearing="123", domain="dev",lp="",project="flyte",task="",wf=""} 43
 	`
 	err = testutil.CollectAndCompare(g.GaugeVec, strings.NewReader(header+expected))
 	assert.NoError(t, err)
 
 	g.Dec(ctx)
 	expected = `
-	   testscope:unittest{bearing="", domain="dev",lp="",project="flyte",task="",wf=""} 1
-       testscope:unittest{bearing="123", domain="dev",lp="",project="flyte",task="",wf=""} 42
+		testscope:unittest{bearing="", domain="dev",lp="",project="flyte",task="",wf=""} 1
+		testscope:unittest{bearing="123", domain="dev",lp="",project="flyte",task="",wf=""} 42
 	`
 	err = testutil.CollectAndCompare(g.GaugeVec, strings.NewReader(header+expected))
 	assert.NoError(t, err)
 
 	g.Sub(ctx, 42)
 	expected = `
-	   testscope:unittest{bearing="", domain="dev",lp="",project="flyte",task="",wf=""} 1
-       testscope:unittest{bearing="123", domain="dev",lp="",project="flyte",task="",wf=""} 0
+		testscope:unittest{bearing="", domain="dev",lp="",project="flyte",task="",wf=""} 1
+		testscope:unittest{bearing="123", domain="dev",lp="",project="flyte",task="",wf=""} 0
 	`
 	err = testutil.CollectAndCompare(g.GaugeVec, strings.NewReader(header+expected))
 	assert.NoError(t, err)

--- a/promutils/labeled/gauge_test.go
+++ b/promutils/labeled/gauge_test.go
@@ -65,3 +65,62 @@ func TestLabeledGauge(t *testing.T) {
 
 	g.SetToCurrentTime(ctx)
 }
+
+func TestWithAdditionalLabels(t *testing.T) {
+	UnsetMetricKeys()
+	assert.NotPanics(t, func() {
+		SetMetricKeys(contextutils.ProjectKey, contextutils.DomainKey, contextutils.WorkflowIDKey, contextutils.TaskIDKey, contextutils.LaunchPlanIDKey)
+	})
+
+	scope := promutils.NewScope("testscope")
+	ctx := context.Background()
+	ctx = contextutils.WithProjectDomain(ctx, "flyte", "dev")
+	g := NewGauge("unittest", "some desc", scope, AdditionalLabelsOption{Labels:[]string{"bearing"}})
+	assert.NotNil(t, g)
+
+	const header = `
+		# HELP testscope:unittest some desc
+        # TYPE testscope:unittest gauge
+	`
+
+	g.Inc(ctx)
+	var expected = `
+        testscope:unittest{bearing="", domain="dev",lp="",project="flyte",task="",wf=""} 1
+	`
+	err := testutil.CollectAndCompare(g.GaugeVec, strings.NewReader(header+expected))
+	assert.NoError(t, err)
+
+	bearingKey := contextutils.Key("bearing")
+	ctx = context.WithValue(ctx, bearingKey, "123")
+	g.Set(ctx, 42)
+	expected = `
+	   testscope:unittest{bearing="", domain="dev",lp="",project="flyte",task="",wf=""} 1
+       testscope:unittest{bearing="123", domain="dev",lp="",project="flyte",task="",wf=""} 42
+	`
+	err = testutil.CollectAndCompare(g.GaugeVec, strings.NewReader(header+expected))
+	assert.NoError(t, err)
+
+	g.Add(ctx, 1)
+	expected = `
+	   testscope:unittest{bearing="", domain="dev",lp="",project="flyte",task="",wf=""} 1
+       testscope:unittest{bearing="123", domain="dev",lp="",project="flyte",task="",wf=""} 43
+	`
+	err = testutil.CollectAndCompare(g.GaugeVec, strings.NewReader(header+expected))
+	assert.NoError(t, err)
+
+	g.Dec(ctx)
+	expected = `
+	   testscope:unittest{bearing="", domain="dev",lp="",project="flyte",task="",wf=""} 1
+       testscope:unittest{bearing="123", domain="dev",lp="",project="flyte",task="",wf=""} 42
+	`
+	err = testutil.CollectAndCompare(g.GaugeVec, strings.NewReader(header+expected))
+	assert.NoError(t, err)
+
+	g.Sub(ctx, 42)
+	expected = `
+	   testscope:unittest{bearing="", domain="dev",lp="",project="flyte",task="",wf=""} 1
+       testscope:unittest{bearing="123", domain="dev",lp="",project="flyte",task="",wf=""} 0
+	`
+	err = testutil.CollectAndCompare(g.GaugeVec, strings.NewReader(header+expected))
+	assert.NoError(t, err)
+}

--- a/promutils/labeled/gauge_test.go
+++ b/promutils/labeled/gauge_test.go
@@ -75,17 +75,17 @@ func TestWithAdditionalLabels(t *testing.T) {
 	scope := promutils.NewScope("testscope")
 	ctx := context.Background()
 	ctx = contextutils.WithProjectDomain(ctx, "flyte", "dev")
-	g := NewGauge("unittest", "some desc", scope, AdditionalLabelsOption{Labels:[]string{"bearing"}})
+	g := NewGauge("unittestlabeled", "some desc", scope, AdditionalLabelsOption{Labels: []string{"bearing"}})
 	assert.NotNil(t, g)
 
 	const header = `
-		# HELP testscope:unittest some desc
-		# TYPE testscope:unittest gauge
+		# HELP testscope:unittestlabeled some desc
+		# TYPE testscope:unittestlabeled gauge
 	`
 
 	g.Inc(ctx)
 	var expected = `
-        testscope:unittest{bearing="", domain="dev",lp="",project="flyte",task="",wf=""} 1
+        testscope:unittestlabeled{bearing="", domain="dev",lp="",project="flyte",task="",wf=""} 1
 	`
 	err := testutil.CollectAndCompare(g.GaugeVec, strings.NewReader(header+expected))
 	assert.NoError(t, err)
@@ -94,32 +94,32 @@ func TestWithAdditionalLabels(t *testing.T) {
 	ctx = context.WithValue(ctx, bearingKey, "123")
 	g.Set(ctx, 42)
 	expected = `
-		testscope:unittest{bearing="", domain="dev",lp="",project="flyte",task="",wf=""} 1
-		testscope:unittest{bearing="123", domain="dev",lp="",project="flyte",task="",wf=""} 42
+		testscope:unittestlabeled{bearing="", domain="dev",lp="",project="flyte",task="",wf=""} 1
+		testscope:unittestlabeled{bearing="123", domain="dev",lp="",project="flyte",task="",wf=""} 42
 	`
 	err = testutil.CollectAndCompare(g.GaugeVec, strings.NewReader(header+expected))
 	assert.NoError(t, err)
 
 	g.Add(ctx, 1)
 	expected = `
-		testscope:unittest{bearing="", domain="dev",lp="",project="flyte",task="",wf=""} 1
-		testscope:unittest{bearing="123", domain="dev",lp="",project="flyte",task="",wf=""} 43
+		testscope:unittestlabeled{bearing="", domain="dev",lp="",project="flyte",task="",wf=""} 1
+		testscope:unittestlabeled{bearing="123", domain="dev",lp="",project="flyte",task="",wf=""} 43
 	`
 	err = testutil.CollectAndCompare(g.GaugeVec, strings.NewReader(header+expected))
 	assert.NoError(t, err)
 
 	g.Dec(ctx)
 	expected = `
-		testscope:unittest{bearing="", domain="dev",lp="",project="flyte",task="",wf=""} 1
-		testscope:unittest{bearing="123", domain="dev",lp="",project="flyte",task="",wf=""} 42
+		testscope:unittestlabeled{bearing="", domain="dev",lp="",project="flyte",task="",wf=""} 1
+		testscope:unittestlabeled{bearing="123", domain="dev",lp="",project="flyte",task="",wf=""} 42
 	`
 	err = testutil.CollectAndCompare(g.GaugeVec, strings.NewReader(header+expected))
 	assert.NoError(t, err)
 
 	g.Sub(ctx, 42)
 	expected = `
-		testscope:unittest{bearing="", domain="dev",lp="",project="flyte",task="",wf=""} 1
-		testscope:unittest{bearing="123", domain="dev",lp="",project="flyte",task="",wf=""} 0
+		testscope:unittestlabeled{bearing="", domain="dev",lp="",project="flyte",task="",wf=""} 1
+		testscope:unittestlabeled{bearing="123", domain="dev",lp="",project="flyte",task="",wf=""} 0
 	`
 	err = testutil.CollectAndCompare(g.GaugeVec, strings.NewReader(header+expected))
 	assert.NoError(t, err)

--- a/promutils/labeled/gauge_test.go
+++ b/promutils/labeled/gauge_test.go
@@ -80,7 +80,7 @@ func TestWithAdditionalLabels(t *testing.T) {
 
 	const header = `
 		# HELP testscope:unittest some desc
-        # TYPE testscope:unittest gauge
+		# TYPE testscope:unittest gauge
 	`
 
 	g.Inc(ctx)

--- a/promutils/labeled/stopwatch.go
+++ b/promutils/labeled/stopwatch.go
@@ -28,7 +28,7 @@ type StopWatch struct {
 //   ....
 // }
 func (c StopWatch) Start(ctx context.Context) Timer {
-	w, err := c.StopWatchVec.GetMetricWith(contextutils.Values(ctx, metricKeys...))
+	w, err := c.StopWatchVec.GetMetricWith(contextutils.Values(ctx, append(metricKeys, c.additionalLabels...)...))
 	if err != nil {
 		panic(err.Error())
 	}


### PR DESCRIPTION
# TL;DR
Some of the labeled metrics forgot to add the additional labels.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

## Complete description
In all the places where we call GetMetricWith, we now pass the additional labels.

## Tracking Issue
NA

## Follow-up issue
NA
