### PR TITLE
Fix container name logging

### DIFF
--- a/storage/stow_store.go
+++ b/storage/stow_store.go
@@ -127,7 +127,7 @@ func (s *StowStore) LoadContainer(ctx context.Context, container string, createI
 	c, err := s.loc.Container(container)
 	if err != nil {
 		if createIfNotFound {
-			logger.Infof(ctx, "Container [%s] lookup failed, err [%s], will try to create a new one", err)
+			logger.Infof(ctx, "Container [%s] lookup failed, err [%s], will try to create a new one", container, err)
 			if IsNotFound(err) || awsBucketIsNotFound(err) {
 				c, err := s.loc.CreateContainer(container)
 				// If the container's already created, move on. Otherwise, fail with error.


### PR DESCRIPTION
# TL;DR
There is a missing parameter when logging, so container name is not logged.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
This is a minor fix that doesn't require design.

## Tracking Issue

## Follow-up issue
